### PR TITLE
PT-2553: No ip in the info sent by ping back

### DIFF
--- a/pingback-client/pingback-client-api/src/main/resources/META-INF/components.txt
+++ b/pingback-client/pingback-client-api/src/main/resources/META-INF/components.txt
@@ -3,6 +3,7 @@ org.phenotips.pingback.internal.client.DefaultPingSender
 org.phenotips.pingback.internal.client.data.DistributionPingDataProvider
 org.phenotips.pingback.internal.client.data.ExtensionPingDataProvider
 org.phenotips.pingback.internal.client.data.DatePingDataProvider
+org.phenotips.pingback.internal.client.data.IPPingDataProvider
 org.phenotips.pingback.internal.client.data.JavaPingDataProvider
 org.phenotips.pingback.internal.client.data.OsPingDataProvider
 org.phenotips.pingback.internal.client.data.DatabasePingDataProvider


### PR DESCRIPTION
- components.txt was missing an import for IPPingDataProvider
- thank you Sergiu for your help